### PR TITLE
Create order-of-compilation.md

### DIFF
--- a/en/cjdns/order-of-compilation.md
+++ b/en/cjdns/order-of-compilation.md
@@ -1,4 +1,4 @@
-Here is the order of compilation on Linux of `*.c` files when `./do` spawns `gcc` using '`-c`', '`-S`' or '`-E`':
+Here is the order of compilation on  my Linux box (3.13.0-43-generic #72-Ubuntu SMP x86_64) of `*.c` files when `./do` spawns `gcc` using '`-c`', '`-S`' or '`-E`':
 
 The top-most files were compiled first, and has the least number of dependencies. This listing includes the compilation of `cnacl` and `libuv` libraries included in the source tree.
 


### PR DESCRIPTION
Hi, I am maybefbi from the HypeIRC forums. This is the order of compilation in the CJDNS project.

I created it using a btrace (https://github.com/rprichard/sourceweb/blob/master/btrace/sw-btrace) which loads a shared object into the ./do process which logs to the file when new processes are spawned from it. I parsed the JSON output it generated and looked for spawns of gcc with -c, -S or -E flags.
