### PR TITLE
Update EZCrypt links to use NCrypt

### DIFF
--- a/benchmark.txt
+++ b/benchmark.txt
@@ -4,7 +4,7 @@ To make your own benchmark:
 cat /proc/cpuinfo
 git log | head -n 1
 
-Paste results to https://ezcrypt.it/ and tell us about it in the IRC channel!
+Paste results to https://ncry.pt/ and tell us about it in the IRC channel!
 Weird processors wanted :D
 
 

--- a/cjdns/Operator_Guidelines.md
+++ b/cjdns/Operator_Guidelines.md
@@ -37,7 +37,7 @@ $ cat /dev/urandom | strings | head -n 20 | tr -d '\n"`\ \t{}' | head -c 40 && e
 
 ```
 
-DO NOT transfer peering credentials over any sort of plaintext medium, such as IRC or unencrypted email. It's probably also a good idea to use a service like [EZCrypt](https://ezcrypt.it) (also available [on Hyperboria](http://cjdns.ezcrypt.it)) or send your peering details via encrypted email with PGP.
+DO NOT transfer peering credentials over any sort of plaintext medium, such as IRC or unencrypted email. It's probably also a good idea to use a service like [NCrypt](https://ncry.pt) (also available [on Hyperboria](http://cjdns.ncryp.pt)) or send your peering details via encrypted email with PGP.
 
 ---
 

--- a/notes/dns.md
+++ b/notes/dns.md
@@ -41,8 +41,8 @@ Now might be a good time to actually figure out how we're going to move forward.
   - https://pad.meshwith.me/p/rainflydns #thx
   - http://gitboria.com/cjd/rainflydns/
   - http://rfdns.cjdns.ca/
-  - https://ezcrypt.it/ck5n#gYdfOeREHwzD92H0WDry4Z5e
-  - https://ezcrypt.it/9Q6n#ejSF9d762REt7hmJ8pl46yp7
+  - https://ncry.pt/ck5n#gYdfOeREHwzD92H0WDry4Z5e
+  - https://ncry.pt/9Q6n#ejSF9d762REt7hmJ8pl46yp7
 - EmerCoin DNS (by emercoin.com) # similar to namecoin with notable differences
     - Longer names allowed than namecoin (512 instead of 255 bytes)
     - Longer values allowed than namecoin (20*1024 instead of 1023 bytes)


### PR DESCRIPTION
ezcrypt.it migrated to ncry.pt