### PR TITLE
Fix link paths to other docs in the build-on-windows.md file

### DIFF
--- a/install/build-on-windows.md
+++ b/install/build-on-windows.md
@@ -88,6 +88,6 @@ The system churns for a while, hopefully producing no errors. It will eventually
 
 Or put cjdroute.exe wherever you like.
 
-Continue following [instructions here](../windows.md#run-time-dependencies)
+Continue following [instructions here](windows.md#run-time-dependencies)
 
-And obviously [secure your shit](windows-firewall.md)
+And obviously [secure your shit](../config/windows-firewall.md)

--- a/install/build-on-windows.md
+++ b/install/build-on-windows.md
@@ -2,7 +2,6 @@ CultureSpy worked out how to compile cjdns for Windows for Windows. So if you ha
 
 # Building cjdns On Windows For Windows
 
-
 Install Cygwin from [here](https://cygwin.com/install.html)
 
 Extra packages to install, if they're not installed by default:
@@ -33,9 +32,7 @@ make
 
 [Install node.js](https://nodejs.org/download/)
 
-
 Get the [cjdns source](https://github.com/cjdelisle/cjdns)
-
 
 Create `C:\tmp`
 
@@ -61,6 +58,7 @@ Make a small edit to the cjdns JS build system:
      logLevel:       process.env['Log_LEVEL'] || 'DEBUG'
  }, function (builder, waitFor) {
 ```
+
 (that is, replace the line that says `tempDir: '/tmp'` with `tempDir: 'C:\\tmp'`)
 
 This works around an issue with the detection of the tmp directory.

--- a/install/windows.md
+++ b/install/windows.md
@@ -1,8 +1,7 @@
 # Building for Windows
 
-* If you're trying to build **on** windows, forget it, you wouldn't build software for an iPhone
-**on** an iPhone...
-* you must have at least Windows Vista because cjdns requires ConvertInterfaceLuidToGuid function https://msdn.microsoft.com/en-us/library/windows/hardware/ff546156%28v=vs.85%29.aspx indtroduced in Vista.
+* If you're trying to build **on** windows, forget it, you wouldn't build software for an iPhone **on** an iPhone...
+* you must have at least Windows Vista because cjdns requires ConvertInterfaceLuidToGuid function https://msdn.microsoft.com/en-us/library/windows/hardware/ff546156%28v=vs.85%29.aspx introduced in Vista.
 
 ## Build Prerequisites
 
@@ -16,7 +15,6 @@ For older Ubuntu:
 
     sudo apt-get install gcc-mingw32
 
-
 ## Build Process
 
 Cross-compile cjdns with the following command:
@@ -28,6 +26,7 @@ Cross-compile cjdns with the following command:
 On your Windows machine, you need the TAP driver installed to allow cjdns to create its virtual network interface. You can get it from the OpenVPN project at their [main download page](https://openvpn.net/index.php/open-source/downloads.html), under "Tap-windows", or use [this direct link to version 9.9.2_3](https://swupdate.openvpn.org/community/releases/tap-windows-9.9.2_3.exe).
 
 Check name of your new virtual connection it must contain only english letters or numbers
+
 ## Installation
 
 Once the TAP driver is installed, copy the `cjdroute.exe` file over to your windows machine.


### PR DESCRIPTION
The links in build-on-windows.md were pointing to old locations and I've updated them to work again. I also made a few simple tweaks to fix some bad practices I noticed along the way.

Cheers!